### PR TITLE
Add CI workflow config

### DIFF
--- a/bin/.github/workflows/ci.yml
+++ b/bin/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  overcommit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .tool-versions
+          bundler-cache: true
+
+      - name: Run Overcommit
+        run: bundle exec overcommit --run


### PR DESCRIPTION
We will use github actions to run CI for this
repo. It should use overcommit to run the
required actions on all files.