### PR TITLE
Add test_helper file

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require File.expand_path("../../lib/turnip", __FILE__)

--- a/test/turnip/cli_test.rb
+++ b/test/turnip/cli_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "minitest/autorun"
-require_relative "../../lib/turnip/cli"
+require "test_helper"
 
 class CLITest < Minitest::Test
   def test_search

--- a/test/turnip/options_test.rb
+++ b/test/turnip/options_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-require "minitest/autorun"
-require_relative "../../lib/turnip/options"
+require "test_helper"
 
 class OptionsTest < Minitest::Test
   def test_parse


### PR DESCRIPTION
This makes creating and managing tests simpler, as common requirements can be added in one place. Also loading file paths automatically saves the trouble of doing it manually. I guess this makes it more expensive to run individual tests though.